### PR TITLE
Fix the package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ class access_insights_client(
     package {'redhat-access-insights':
       ensure   => latest,
       provider => yum,
-      source   => 'redhat-access-insights',
+      name     => 'insights-client',
     }
 
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,10 +56,20 @@ class access_insights_client(
     $obsfucate_hostname = undef,
     $upload_schedule = undef,
 ){
+
+    case $::operatingsystemmajrelease {
+      7: {
+        $insights_package = 'insights-client'
+      }
+      default: {
+        $insights_package = 'redhat-access-insights'
+      }
+    }
+
     package {'redhat-access-insights':
       ensure   => latest,
       provider => yum,
-      name     => 'insights-client',
+      name     => $insights_package,
     }
 
     file {'/etc/redhat-access-insights/redhat-access-insights.conf':


### PR DESCRIPTION
New package name

The package was renamed and the virtual package won't work for a puppet verify its installed. What happens is the puppet run will keep attempting to install the new package.