### PR TITLE
Handle the new package structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The module can be used in RHEL hosts subscribed directly to the Red Hat CDN, or 
 
 ### What access_insights_client affects
 
-* This module will install the latest `redhat-access-insights` rpm package and install cron jobs in either `/etc/cron.daily/redhat-access-insights` or `/etc/cron.weekly/redhat-access-insights`, depending on how it is configured.
+* This module will install the latest `redhat-access-insights` rpm package and install cron jobs in `/etc/cron.daily/redhat-access-insights` or a systemd timer.
 
-###Setup Requirements
+### Setup Requirements
 
 RHEL hosts need to be subscribed to the Red Hat CDN or Satellite in order to fulfill Red Hat Access Insights rpm dependencies.
 

--- a/manifests/current.pp
+++ b/manifests/current.pp
@@ -28,8 +28,6 @@
 #   Whether to obfuscate IP addresses.
 # @param obfuscate_hostname
 #   Whether to obfuscate hostname.
-# @param upload_schedule
-#   How often to update. Can be daily or weekly.
 #
 # @author Lindani Phiri <lphiri@redhat.com>
 # @author Dan Varga  <dvarga@redhat.com>
@@ -50,7 +48,6 @@ class access_insights_client::current (
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
-  $upload_schedule = undef,
 ) {
   package { $package_name:
     ensure => installed,
@@ -79,33 +76,19 @@ class access_insights_client::current (
         ensure => 'absent',
     }
 
-    # TODO: how to override the schedule?
-
     service { "${package_name}.timer":
       ensure => 'running',
       enable => true,
     }
   } else {
-    if $upload_schedule == 'weekly' {
-      file { "/etc/cron.weekly/${package_name}":
-        ensure  => 'link',
-        target  => "/etc/${package_name}/${package_name}.cron",
-        require => Package[$package_name],
-      }
+    file { "/etc/cron.daily/${package_name}":
+      ensure  => 'link',
+      target  => "/etc/${package_name}/${package_name}.cron",
+      require => Package[$package_name],
+    }
 
-      file { "/etc/cron.daily/${package_name}":
-        ensure => 'absent',
-      }
-    } else {
-      file { "/etc/cron.daily/${package_name}":
-        ensure  => 'link',
-        target  => "/etc/${package_name}/${package_name}.cron",
-        require => Package[$package_name],
-      }
-
-      file { "/etc/cron.weekly/${package_name}":
-        ensure => 'absent',
-      }
+    file { "/etc/cron.weekly/${package_name}":
+      ensure => 'absent',
     }
   }
 

--- a/manifests/current.pp
+++ b/manifests/current.pp
@@ -1,0 +1,117 @@
+# @summary
+#   The current style deployment for Red Hat 6.10+ and Red Hat 7.5+.
+#
+# @param package_name
+#   The name of the package to install
+# @param log_level
+#   Change log level, valid options DEBUG, INFO, WARNING, ERROR, CRITICAL.
+# @param auto_config
+#   Attempt to auto configure with Satellite server.
+# @param authmethod
+#   Change authentication method, valid options BASIC, CERT.
+# @param username
+#   username to use when authmethod is BASIC.
+# @param password
+#   password to use when authmethod is BASIC.
+# @param base_url
+#   URL for your proxy. Example: http://user:pass@192.168.100.50:8080
+# @param proxy
+#   Proxy to use.
+# @param cert_verify
+#   How to verify the certificate chain of api.access.redhat.com. Can be True,
+#   False or an absolute path.
+# @param gpg
+#   Enable/Disable GPG verification of dynamic configuration.
+# @param auto_update
+#   Automatically update the dynamic configuration.
+# @param obfuscate
+#   Whether to obfuscate IP addresses.
+# @param obfuscate_hostname
+#   Whether to obfuscate hostname.
+# @param upload_schedule
+#   How often to update. Can be daily or weekly.
+#
+# @author Lindani Phiri <lphiri@redhat.com>
+# @author Dan Varga  <dvarga@redhat.com>
+#
+# Copyright 2015 Red Hat Inc.
+#
+class access_insights_client::current (
+  $package_name = 'insights-client',
+  $log_level = undef,
+  $auto_config = 'True',
+  $authmethod = undef,
+  $username = undef,
+  $password = undef,
+  $base_url = undef,
+  $proxy = undef,
+  $cert_verify = undef,
+  $gpg = undef,
+  $auto_update = undef,
+  $obfuscate = undef,
+  $obfuscate_hostname = undef,
+  $upload_schedule = undef,
+) {
+  package { $package_name:
+    ensure => installed,
+  }
+
+  # Ensure the old config is gone
+  file { [
+      '/etc/redhat-access-insights/redhat-access-insights.conf',
+      '/etc/cron.daily/redhat-access-insights',
+      '/etc/cron.weekly/redhat-access-insights',
+    ]:
+      ensure  => 'absent',
+  }
+
+  file { "/etc/${package_name}/${package_name}.conf":
+    ensure  => 'file',
+    content => template('access_insights_client/redhat-access-insights.conf.erb'),
+    require => Package[$package_name],
+  }
+
+  if versioncmp($::operatingsystemrelease, '7.0') >= 0 {
+    file { [
+        "/etc/cron.weekly/${package_name}",
+        "/etc/cron.daily/${package_name}",
+      ]:
+        ensure => 'absent',
+    }
+
+    # TODO: how to override the schedule?
+
+    service { "${package_name}.timer":
+      ensure => 'running',
+      enable => true,
+    }
+  } else {
+    if $upload_schedule == 'weekly' {
+      file { "/etc/cron.weekly/${package_name}":
+        ensure  => 'link',
+        target  => "/etc/${package_name}/${package_name}.cron",
+        require => Package[$package_name],
+      }
+
+      file { "/etc/cron.daily/${package_name}":
+        ensure => 'absent',
+      }
+    } else {
+      file { "/etc/cron.daily/${package_name}":
+        ensure  => 'link',
+        target  => "/etc/${package_name}/${package_name}.cron",
+        require => Package[$package_name],
+      }
+
+      file { "/etc/cron.weekly/${package_name}":
+        ensure => 'absent',
+      }
+    }
+  }
+
+  exec { "/usr/bin/${package_name} --register":
+    creates => "/etc/${package_name}/.registered",
+    unless  => "/usr/bin/test -f /etc/${package_name}/.unregistered",
+    require => Package[$package_name],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,8 +27,6 @@
 #   Whether to obfuscate IP addresses.
 # @param obfuscate_hostname
 #   Whether to obfuscate hostname.
-# @param upload_schedule
-#   How often to update. Can be daily or weekly.
 # @param deployment_style
 #   How the module should be deploy. Can be undef (auto),
 #   current (6.10+ or 7.5+) or old.
@@ -51,7 +49,6 @@ class access_insights_client(
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
-  $upload_schedule = undef,
   $deployment_style = undef,
 ) {
   if $deployment_style {
@@ -78,6 +75,5 @@ class access_insights_client(
     auto_update        => $auto_update,
     obfuscate          => $obfuscate,
     obfuscate_hostname => $obfuscate_hostname,
-    upload_schedule    => $upload_schedule,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # @summary
-#   Full description of class access_insights_client here.
+#   The access insights module is intended to deploy and configure the Red Hat
+#   Access Insights client.
 #
 # @param log_level
 #   Change log level, valid options DEBUG, INFO, WARNING, ERROR, CRITICAL.

--- a/manifests/old.pp
+++ b/manifests/old.pp
@@ -29,8 +29,6 @@
 #   Whether to obfuscate IP addresses.
 # @param obfuscate_hostname
 #   Whether to obfuscate hostname.
-# @param upload_schedule
-#   How often to update. Can be daily or weekly.
 #
 # @author Lindani Phiri <lphiri@redhat.com>
 # @author Dan Varga  <dvarga@redhat.com>
@@ -51,7 +49,6 @@ class access_insights_client::old (
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
-  $upload_schedule = undef,
 ) {
   package { $package_name:
     ensure => latest,
@@ -63,26 +60,14 @@ class access_insights_client::old (
     require => Package[$package_name],
   }
 
-  if $upload_schedule == 'weekly' {
-    file { "/etc/cron.weekly/${package_name}":
-      ensure  => 'link',
-      target  => "/etc/${package_name}/${package_name}.cron",
-      require => Package[$package_name],
-    }
+  file { "/etc/cron.daily/${package_name}":
+    ensure  => 'link',
+    target  => "/etc/${package_name}/${package_name}.cron",
+    require => Package[$package_name],
+  }
 
-    file { "/etc/cron.daily/${package_name}":
-      ensure => 'absent',
-    }
-  } else {
-    file { "/etc/cron.daily/${package_name}":
-      ensure  => 'link',
-      target  => "/etc/${package_name}/${package_name}.cron",
-      require => Package[$package_name],
-    }
-
-    file { "/etc/cron.weekly/${package_name}":
-      ensure => 'absent',
-    }
+  file { "/etc/cron.weekly/${package_name}":
+    ensure => 'absent',
   }
 
   exec { "/usr/bin/${package_name} --register":

--- a/spec/classes/current_spec.rb
+++ b/spec/classes/current_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'access_insights_client::current' do
+  context 'on 6.10' do
+    let :facts do
+      {:operatingsystemrelease => '6.10'}
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it { is_expected.to contain_file('/etc/redhat-access-insights/redhat-access-insights.conf').with_ensure('absent') }
+    it { is_expected.to contain_file('/etc/cron.daily/redhat-access-insights').with_ensure('absent') }
+    it { is_expected.to contain_file('/etc/cron.weekly/redhat-access-insights').with_ensure('absent') }
+
+    it { is_expected.to contain_package('insights-client') }
+    it { is_expected.to contain_file('/etc/cron.daily/insights-client').with_ensure('link').with_target('/etc/insights-client/insights-client.cron') }
+    it { is_expected.to contain_file('/etc/cron.weekly/insights-client').with_ensure('absent') }
+    it { is_expected.to contain_exec('/usr/bin/insights-client --register') }
+    it { is_expected.not_to contain_service('insights-client.timer') }
+  end
+
+  context 'on 7.0' do
+    let :facts do
+      {:operatingsystemrelease => '7.0'}
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it { is_expected.to contain_file('/etc/redhat-access-insights/redhat-access-insights.conf').with_ensure('absent') }
+    it { is_expected.to contain_file('/etc/cron.daily/redhat-access-insights').with_ensure('absent') }
+    it { is_expected.to contain_file('/etc/cron.weekly/redhat-access-insights').with_ensure('absent') }
+
+    it { is_expected.to contain_package('insights-client') }
+    it { is_expected.to contain_file('/etc/insights-client/insights-client.conf').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/cron.daily/insights-client').with_ensure('absent') }
+    it { is_expected.to contain_file('/etc/cron.weekly/insights-client').with_ensure('absent') }
+    it { is_expected.to contain_exec('/usr/bin/insights-client --register') }
+    it { is_expected.to contain_service('insights-client.timer') }
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,10 +1,37 @@
 require 'spec_helper'
 
 describe 'access_insights_client' do
-  context 'with defaults for all parameters' do
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_package('redhat-access-insights') }
-    it { is_expected.to contain_file('/etc/cron.daily/redhat-access-insights').with_ensure('link') }
-    it { is_expected.to contain_file('/etc/cron.weekly/redhat-access-insights').with_ensure('absent') }
+  context 'with explicit deployment style' do
+    context 'on 6.10' do
+      let :params do
+        {:deployment_style => 'old'}
+      end
+
+      let :facts do
+        {:operatingsystemrelease => '6.10'}
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('access_insights_client::old') }
+    end
+  end
+
+  context 'with autodetection' do
+    {
+      '6.9' => 'old',
+      '6.10' => 'current',
+      '7.0' => 'old',
+      '7.4' => 'old',
+      '7.5' => 'current',
+    }.each do |version, expected|
+      context "on #{version}" do
+        let :facts do
+          {:operatingsystemrelease => version}
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class("access_insights_client::#{expected}") }
+      end
+    end
   end
 end

--- a/spec/classes/old_spec.rb
+++ b/spec/classes/old_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'access_insights_client::old' do
+  context 'with defaults for all parameters' do
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_package('redhat-access-insights') }
+    it { is_expected.to contain_file('/etc/cron.daily/redhat-access-insights').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/cron.weekly/redhat-access-insights').with_ensure('absent') }
+    it { is_expected.to contain_exec('/usr/bin/redhat-access-insights --register') }
+  end
+end


### PR DESCRIPTION
Since RHEL 6.10 and RHEL 7.5 the package was renamed from redhat-access-insights to insights-client. When systemd is present, a timer unit is used instead of cron.

We use facts to automatically determine which package should be present, but this can fail when content views are used. Because of that a new parameter is introduced.

**Note** Please let me know if this is correct. I haven't had a chance to test this on a real system yet.