### PR TITLE
dont use ensure => latest

### DIFF
--- a/manifests/old.pp
+++ b/manifests/old.pp
@@ -51,7 +51,7 @@ class access_insights_client::old (
   $obfuscate_hostname = undef,
 ) {
   package { $package_name:
-    ensure => latest,
+    ensure => installed,
   }
 
   file { "/etc/${package_name}/${package_name}.conf":


### PR DESCRIPTION
Use of `ensure => latest` was observed to cause extreme load in very large Katello deployments. `ensure => installed` will reduce that load by not checking for updates of the package and would instead rely on the package being updated during normal patching cycles.

NOTE: we are already using `ensure => installed` in current.pp so this change is only necessary in old.pp