### PR TITLE
Add support for managing tags

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,4 @@
+---
+fixtures:
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"

--- a/manifests/current.pp
+++ b/manifests/current.pp
@@ -28,6 +28,9 @@
 #   Whether to obfuscate IP addresses.
 # @param obfuscate_hostname
 #   Whether to obfuscate hostname.
+# @param tags
+#   Data Hash to populate tags.yaml file
+#
 #
 # @author Lindani Phiri <lphiri@redhat.com>
 # @author Dan Varga  <dvarga@redhat.com>
@@ -48,6 +51,7 @@ class access_insights_client::current (
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
+  Hash $tags = {},
 ) {
   package { $package_name:
     ensure => installed,
@@ -91,6 +95,11 @@ class access_insights_client::current (
     file { "/etc/cron.weekly/${package_name}":
       ensure => 'absent',
     }
+  }
+
+  file { "/etc/${package_name}/tags.yaml":
+    content => to_yaml($tags),
+    require => Package[$package_name],
   }
 
   exec { "/usr/bin/${package_name} --register":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@
 # @param deployment_style
 #   How the module should be deploy. Can be undef (auto),
 #   current (6.10+ or 7.5+) or old.
+# @param tags
+#   Data Hash to populate tags.yaml file
 #
 # @author Lindani Phiri <lphiri@redhat.com>
 # @author Dan Varga  <dvarga@redhat.com>
@@ -49,6 +51,7 @@ class access_insights_client (
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
+  Hash $tags = {},
   Optional[Enum['current', 'old']] $deployment_style = undef,
 ) {
   if $deployment_style {
@@ -75,6 +78,7 @@ class access_insights_client (
     auto_update        => $auto_update,
     obfuscate          => $obfuscate,
     obfuscate_hostname => $obfuscate_hostname,
+    tags               => $tags,
   }
   contain "access_insights_client::${class_name}"
 }

--- a/manifests/old.pp
+++ b/manifests/old.pp
@@ -29,6 +29,8 @@
 #   Whether to obfuscate IP addresses.
 # @param obfuscate_hostname
 #   Whether to obfuscate hostname.
+# @param tags
+#   Data Hash to populate tags.yaml file ---> This will not work for the old style of deployment.
 #
 # @author Lindani Phiri <lphiri@redhat.com>
 # @author Dan Varga  <dvarga@redhat.com>
@@ -49,7 +51,12 @@ class access_insights_client::old (
   $auto_update = undef,
   $obfuscate = undef,
   $obfuscate_hostname = undef,
+  Hash $tags = {},
 ) {
+  if !$tags.empty {
+    fail('You cant use tags with this implementation')
+  }
+
   package { $package_name:
     ensure => installed,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,10 @@
     {
       "name": "puppet",
       "version_requirement": ">= 6.1.0 < 8.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.20.0"
     }
   ]
 }

--- a/spec/classes/current_spec.rb
+++ b/spec/classes/current_spec.rb
@@ -36,5 +36,14 @@ describe 'access_insights_client::current' do
     it { is_expected.to contain_file('/etc/cron.weekly/insights-client').with_ensure('absent') }
     it { is_expected.to contain_exec('/usr/bin/insights-client --register') }
     it { is_expected.to contain_service('insights-client.timer') }
+    it { is_expected.to contain_file('/etc/insights-client/tags.yaml').with_content(%r{^--- \{\}$}) }
+
+    context 'with tags' do
+      let :params do
+        {tags: {'foo': 'bar'}}
+      end
+
+      it { is_expected.to contain_file('/etc/insights-client/tags.yaml').with_content(%r{^---\nfoo: bar$}) }
+    end
   end
 end


### PR DESCRIPTION
The access-insights client supports tags configured via a tags.yaml file. This creates the tags.yaml file.
Addditionally stdlib is added as a requirement to use the to_yaml function.